### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Pivotal Software Inc.",
   "private": true,
   "engines": {
-    "node": "4.2.5"
+    "node": "4.4.2"
   },
   "dependencies": {
     "express": "^4.13.4",


### PR DESCRIPTION
DEPENDENCY MISSING IN MANIFEST: node 4.2.5
It looks like you're trying to use node 4.2.5.
Unfortunately, that version of node is not supported by this buildpack.

The versions of node supported in this buildpack are:
- 6.0.0
- 5.11.0
- 5.10.1
- 4.4.2
- 0.12.13
- 0.12.12
- 0.10.44
- 4.4.3
- 0.10.43
